### PR TITLE
Add support for PHP 8.4 + 8.5 in test matrix

### DIFF
--- a/.github/workflows/phpcs.yaml
+++ b/.github/workflows/phpcs.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['8.3']
+        php-versions: ['8.3', '8.4', '8.5']
     name: running on ${{ matrix.operating-system }} / PHP v${{ matrix.php-versions }}
 
     steps:

--- a/.github/workflows/phpmd.yaml
+++ b/.github/workflows/phpmd.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['8.3']
+        php-versions: ['8.3', '8.4', '8.5']
     name: running on ${{ matrix.operating-system }} / PHP v${{ matrix.php-versions }}
 
     steps:

--- a/.github/workflows/phpstan.yaml
+++ b/.github/workflows/phpstan.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['8.3']
+        php-versions: ['8.3', '8.4', '8.5']
     name: running on ${{ matrix.operating-system }} / PHP v${{ matrix.php-versions }}
 
     steps:

--- a/.github/workflows/phpunit.yaml
+++ b/.github/workflows/phpunit.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macOS-latest]
-        php-versions: ['8.3']
+        php-versions: ['8.3', '8.4', '8.5']
     name: running on ${{ matrix.operating-system }} / PHP v${{ matrix.php-versions }}
 
     steps:


### PR DESCRIPTION
Since the composer.json file declares compatibility starting from version 8.3, it is advisable to test every available version from that point onward on the runners.